### PR TITLE
fixed error popups on both furniture order and supply order

### DIFF
--- a/src/main/java/edu/wpi/fishfolk/controllers/NewFurnitureOrderController.java
+++ b/src/main/java/edu/wpi/fishfolk/controllers/NewFurnitureOrderController.java
@@ -197,6 +197,7 @@ public class NewFurnitureOrderController extends AbsController {
   void submit() {
     setServiceTypeToRadios();
     setItemToRadios();
+
     if (currentFurnitureOrder.furnitureItem == null
         || currentFurnitureOrder.serviceType == null
         || roomSelector.getValue() == null
@@ -205,12 +206,25 @@ public class NewFurnitureOrderController extends AbsController {
       Text errorText = new Text("One or more required fields have not been filled");
       errorText.setFont(new Font("Open Sans", 26));
       error.setContentNode(errorText);
+      error.setArrowLocation(PopOver.ArrowLocation.BOTTOM_RIGHT);
       error.show(furnituresubmitButton);
       return;
     }
+
     currentFurnitureOrder.setRoomNum(roomSelector.getValue());
     currentFurnitureOrder.addNotes(notesTextField.getText());
     currentFurnitureOrder.addDate(getDate());
+
+    if (currentFurnitureOrder.deliveryDate.isBefore(LocalDateTime.now())) {
+      PopOver error = new PopOver();
+      Text errorText = new Text("Cannot set delivery date before current date");
+      errorText.setFont(new Font("Open Sans", 26));
+      error.setContentNode(errorText);
+      error.setArrowLocation(PopOver.ArrowLocation.BOTTOM_RIGHT);
+      error.show(furnituresubmitButton);
+      return;
+    }
+
     currentFurnitureOrder.setStatus(FormStatus.submitted);
     FurnitureRequest request =
         new FurnitureRequest(

--- a/src/main/java/edu/wpi/fishfolk/controllers/NewFurnitureOrderController.java
+++ b/src/main/java/edu/wpi/fishfolk/controllers/NewFurnitureOrderController.java
@@ -215,7 +215,7 @@ public class NewFurnitureOrderController extends AbsController {
     currentFurnitureOrder.addNotes(notesTextField.getText());
     currentFurnitureOrder.addDate(getDate());
 
-    if (currentFurnitureOrder.deliveryDate.isBefore(LocalDateTime.now())) {
+    if (currentFurnitureOrder.deliveryDate.isBefore(LocalDateTime.now().minusDays(1))) {
       PopOver error = new PopOver();
       Text errorText = new Text("Cannot set delivery date before current date");
       errorText.setFont(new Font("Open Sans", 26));

--- a/src/main/java/edu/wpi/fishfolk/controllers/NewSupplyOrderController.java
+++ b/src/main/java/edu/wpi/fishfolk/controllers/NewSupplyOrderController.java
@@ -166,6 +166,7 @@ public class NewSupplyOrderController extends AbsController {
       Text errorText = new Text("One or more required fields have not been filled");
       errorText.setFont(new Font("Open Sans", 26));
       error.setContentNode(errorText);
+      error.setArrowLocation(PopOver.ArrowLocation.BOTTOM_RIGHT);
       error.show(supplySubmitButton);
     }
   }


### PR DESCRIPTION
3 bug fixes in 1! Shows error message if the selected date is before or the same day as current date, as well as fixing the orientation of the preexisting error messages for incomplete forms on furniture order and supply order