### PR TITLE
added duplicate insert check to 7 DAOs (excluded all Map DAOs and Alert)

### DIFF
--- a/src/main/java/edu/wpi/fishfolk/database/DAO/AlertDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/AlertDAO.java
@@ -201,6 +201,7 @@ public class AlertDAO implements IDAO<Alert> {
   @Override
   public boolean insertEntry(Alert entry) {
 
+    // Check if the entry already exists.
     if (alerts.containsKey(entry.getTimestamp())) return false;
 
     // Mark entry Alert status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/ConferenceRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/ConferenceRequestDAO.java
@@ -207,6 +207,9 @@ public class ConferenceRequestDAO implements IDAO<ConferenceRequest> {
   @Override
   public boolean insertEntry(ConferenceRequest entry) {
 
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getConferenceRequestID())) return false;
+
     // Mark entry status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/ConferenceRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/ConferenceRequestDAO.java
@@ -207,7 +207,7 @@ public class ConferenceRequestDAO implements IDAO<ConferenceRequest> {
   @Override
   public boolean insertEntry(ConferenceRequest entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists. Unlikely conflicts.
     if (tableMap.containsKey(entry.getConferenceRequestID())) return false;
 
     // Mark entry status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/FlowerRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/FlowerRequestDAO.java
@@ -214,7 +214,7 @@ public class FlowerRequestDAO implements IDAO<FlowerRequest>, IHasSubtable<Flowe
   @Override
   public boolean insertEntry(FlowerRequest entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists. Unlikely conflicts.
     if (tableMap.containsKey(entry.getFlowerRequestID())) return false;
 
     // Mark entry status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/FlowerRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/FlowerRequestDAO.java
@@ -213,6 +213,10 @@ public class FlowerRequestDAO implements IDAO<FlowerRequest>, IHasSubtable<Flowe
 
   @Override
   public boolean insertEntry(FlowerRequest entry) {
+
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getFlowerRequestID())) return false;
+
     // Mark entry status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/FoodRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/FoodRequestDAO.java
@@ -216,6 +216,9 @@ public class FoodRequestDAO implements IDAO<FoodRequest>, IHasSubtable<NewFoodIt
   @Override
   public boolean insertEntry(FoodRequest entry) {
 
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getFoodRequestID())) return false;
+
     // Mark entry FoodRequest status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/FoodRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/FoodRequestDAO.java
@@ -216,7 +216,7 @@ public class FoodRequestDAO implements IDAO<FoodRequest>, IHasSubtable<NewFoodIt
   @Override
   public boolean insertEntry(FoodRequest entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists. Unlikely conflicts.
     if (tableMap.containsKey(entry.getFoodRequestID())) return false;
 
     // Mark entry FoodRequest status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/FurnitureRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/FurnitureRequestDAO.java
@@ -209,6 +209,10 @@ public class FurnitureRequestDAO implements IDAO<FurnitureRequest> {
 
   @Override
   public boolean insertEntry(FurnitureRequest entry) {
+
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getFurnitureRequestID())) return false;
+
     // Mark entry status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/FurnitureRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/FurnitureRequestDAO.java
@@ -210,7 +210,7 @@ public class FurnitureRequestDAO implements IDAO<FurnitureRequest> {
   @Override
   public boolean insertEntry(FurnitureRequest entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists. Unlikely conflicts.
     if (tableMap.containsKey(entry.getFurnitureRequestID())) return false;
 
     // Mark entry status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/LocationDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/LocationDAO.java
@@ -187,6 +187,9 @@ public class LocationDAO implements IDAO<Location> {
   @Override
   public boolean insertEntry(Location entry) {
 
+    // Check if the entry already exists.
+    if (tableMap.containsKey(entry.getLongName())) return false;
+
     // Mark entry Location status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/MoveDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/MoveDAO.java
@@ -187,6 +187,9 @@ public class MoveDAO implements IDAO<Move> {
   @Override
   public boolean insertEntry(Move entry) {
 
+    // Check if the entry already exists.
+    if (tableMap.containsKey(entry.getMoveID())) return false;
+
     // Mark entry Move status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/NodeDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/NodeDAO.java
@@ -195,6 +195,9 @@ public class NodeDAO implements IDAO<Node> {
   @Override
   public boolean insertEntry(Node entry) {
 
+    // Check if the entry already exists.
+    if (tableMap.containsKey(entry.getNodeID())) return false;
+
     // Mark entry Node status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/SignagePresetDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/SignagePresetDAO.java
@@ -188,7 +188,7 @@ public class SignagePresetDAO implements IDAO<SignagePreset> {
   @Override
   public boolean insertEntry(SignagePreset entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists.
     if (tableMap.containsKey(entry.getName())) return false;
 
     // Mark entry status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/SignagePresetDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/SignagePresetDAO.java
@@ -188,6 +188,9 @@ public class SignagePresetDAO implements IDAO<SignagePreset> {
   @Override
   public boolean insertEntry(SignagePreset entry) {
 
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getName())) return false;
+
     // Mark entry status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/SupplyRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/SupplyRequestDAO.java
@@ -200,7 +200,7 @@ public class SupplyRequestDAO implements IDAO<SupplyRequest>, IHasSubtable<Suppl
   @Override
   public boolean insertEntry(SupplyRequest entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists. Unlikely conflicts.
     if (tableMap.containsKey(entry.getSupplyRequestID())) return false;
 
     // Mark entry status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/SupplyRequestDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/SupplyRequestDAO.java
@@ -200,6 +200,9 @@ public class SupplyRequestDAO implements IDAO<SupplyRequest>, IHasSubtable<Suppl
   @Override
   public boolean insertEntry(SupplyRequest entry) {
 
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getSupplyRequestID())) return false;
+
     // Mark entry status as NEW
     entry.setStatus(EntryStatus.NEW);
 

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/UserAccountDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/UserAccountDAO.java
@@ -190,7 +190,7 @@ public class UserAccountDAO implements IDAO<UserAccount> {
   @Override
   public boolean insertEntry(UserAccount entry) {
 
-    // Check if the entry already exists. Update instead?
+    // Check if the entry already exists.
     if (tableMap.containsKey(entry.getUsername())) return false;
 
     // Mark entry status as NEW

--- a/src/main/java/edu/wpi/fishfolk/database/DAO/UserAccountDAO.java
+++ b/src/main/java/edu/wpi/fishfolk/database/DAO/UserAccountDAO.java
@@ -190,6 +190,9 @@ public class UserAccountDAO implements IDAO<UserAccount> {
   @Override
   public boolean insertEntry(UserAccount entry) {
 
+    // Check if the entry already exists. Update instead?
+    if (tableMap.containsKey(entry.getUsername())) return false;
+
     // Mark entry status as NEW
     entry.setStatus(EntryStatus.NEW);
 


### PR DESCRIPTION
Added a single-line check to `inseryEntry()` in each DAO except for Map DAOs and Alert to check for duplicate IDs. Thinking about whether this should try an update if there is a duplicate, but I worry about accidental issues with that.